### PR TITLE
ci(coverage): generate coverage-summary.json for gate

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'lcov'],
+  // Added 'json-summary' so CI coverage gate (expects coverage/coverage-summary.json)
+  // succeeds; previously only 'json' produced coverage-final.json causing gate failure.
+  reporter: ['text', 'json', 'json-summary', 'lcov'],
       reportsDirectory: 'coverage',
       // Exclude large, non-runtime or archival areas to raise meaningful signal
       exclude: [
@@ -48,9 +50,9 @@ export default defineConfig({
         'src/lib/**/test-*',
         'scripts/**',
         'public/**',
-        '**/*.d.ts'
-      ]
-    }
+        '**/*.d.ts',
+      ],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### Summary\nAdd 'json-summary' reporter to Vitest so coverage/coverage-summary.json is produced. Fixes code_quality job failure where gate aborted because file was missing.\n\n### Root Cause\nCoverage gate script expects coverage/coverage-summary.json. Prior reporters (text,json,lcov) output coverage-final.json instead; gate exited 1 when summary file absent.\n\n### Changes\n- vitest.config.ts: add json-summary reporter (and comment).\n\n### Verification\n- Local run of tests will now emit coverage-summary.json (will rely on CI run to confirm artifact presence and passing gate).\n\n### Follow Ups (optional)\n- Add fallback in gate: if summary missing but coverage-final.json exists, transform and continue.\n- Consider adding mutation or branch coverage tracking later.\n\n### Risk\nLow – only config change; no production code paths affected.\n\n### Requested Action\nReview & merge to restore green pipeline so downstream coverage_delta and baseline_metrics jobs can run.