### PR TITLE
Fix main page styling by importing vitalsense.css

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import App from './App';
 import './lib/pwa'; // Initialize PWA functionality
 import './main.css';
+import './vitalsense.css'; // VitalSense iOS 26 enhanced styles
 import './monitor/rum';
 import './types/global.d.ts';
 

--- a/src/vitalsense.css
+++ b/src/vitalsense.css
@@ -4,13 +4,8 @@
  * Updated for iOS 26 design standards and enhanced accessibility
  */
 
-/* === IMPORTS === */
-@import 'tw-animate-css';
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* === VITALSENSE BRAND THEME - iOS 26 ENHANCED === */
+/* Note: Tailwind directives are in main.css to avoid duplication */
 :root {
   /* VitalSense Brand Colors - iOS 26 Enhanced */
   --vitalsense-primary: #2563eb; /* VitalSense Blue */


### PR DESCRIPTION
The main page was displaying without color or style because vitalsense.css
(which contains VitalSense brand colors and iOS 26 enhanced styles) was not
being imported in the application entry point.

Changes:
- Import vitalsense.css in main.tsx to load VitalSense brand theme
- Remove non-existent tw-animate-css import from vitalsense.css
- Remove duplicate Tailwind directives from vitalsense.css to avoid conflicts
- Add comment clarifying Tailwind directive location

This restores the VitalSense color scheme, iOS 26 enhanced styles, and
component styling to the main page and throughout the application.