### PR TITLE
fix(e2e): repair 30+ mobile-chrome failures in AppPage + DashboardPage

### DIFF
--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -46,9 +46,11 @@ export class AppPage {
   }
 
   /**
-   * Navigate to a tab via the app's custom event system.
-   * Uses window.dispatchEvent('navigate') which the React component listens for.
-   * This bypasses CSS layout issues with the collapsed sidebar.
+   * Navigate to a route by URL — works on all viewports including mobile
+   * where the sidebar is collapsed and sidebar links are not clickable.
+   *
+   * Use `clickSidebarItem()` when the test specifically exercises sidebar
+   * interaction. Use `navigateTo()` for everything else.
    */
   async navigateTo(
     tab: 'dashboard' | 'gait-analysis' | 'lidar-posture' | 'fall-risk' | 'settings',
@@ -60,22 +62,7 @@ export class AppPage {
       'fall-risk': '/fall-risk',
       settings: '/settings',
     };
-    const linkByTab: Record<typeof tab, Locator> = {
-      dashboard: this.dashboardLink,
-      'gait-analysis': this.gaitLink,
-      'lidar-posture': this.lidarLink,
-      'fall-risk': this.fallRiskLink,
-      settings: this.settingsLink,
-    };
-    await linkByTab[tab].click();
-    try {
-      await this.page.waitForURL(new RegExp(`${pathByTab[tab]}$`), {
-        timeout: 10_000,
-      });
-    } catch {
-      // Offline-mode tests can intentionally block route chunk fetches.
-      // Keep assertions focused on graceful degradation, not URL transitions.
-    }
+    await this.page.goto(pathByTab[tab], { waitUntil: 'domcontentloaded' });
     await expect(this.mainContent).toBeVisible();
   }
 

--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -65,6 +65,9 @@ export class DashboardPage {
       devices: this.devicesTab,
     } as const;
     const tabEl = tabs[tab];
+    // Scroll into view first — on mobile the tab bar may be partially
+    // off-screen until the user scrolls, causing click timeouts.
+    await tabEl.scrollIntoViewIfNeeded();
     await tabEl.click();
     await this.page.waitForLoadState('domcontentloaded');
   }


### PR DESCRIPTION
## Root cause

All 30+ nightly E2E failures in `mobile-chrome` trace to two bugs in the page object layer:

### 1. `AppPage.navigateTo()` — sidebar click on hidden element

```ts
// Before: clicks sidebar link scoped to aside — hidden on Pixel 7 viewport
await linkByTab[tab].click();  // TimeoutError: 10000ms exceeded

// After: direct URL navigation, works on all viewports
await this.page.goto(pathByTab[tab], { waitUntil: 'domcontentloaded' });
```

The sidebar (`aside[aria-label="Primary navigation"]`) is collapsed/hidden on the 393px Pixel 7 viewport. Every `beforeEach` calling `navigateTo()` timed out, cascading failures across **fall-risk**, **gait-analysis**, **lidar-posture**, **error-scenarios**, and **settings** specs.

`clickSidebarItem()` remains the right method for tests that specifically exercise sidebar interaction — it already handles expanding the sidebar first.

### 2. `DashboardPage.switchTab()` — tab off-screen on mobile

```ts
// Before: click without scroll
await tabEl.click();  // TimeoutError if tab scrolled off-screen

// After:
await tabEl.scrollIntoViewIfNeeded();
await tabEl.click();
```

On mobile the dashboard tab bar can be partially below the fold. Scroll first, then click.