### PR TITLE
fix(ios): break long line to satisfy SwiftLint line_length rule

### DIFF
--- a/ios/Andernet-Posture/Andernet Posture/Views/MetricExplainerView.swift
+++ b/ios/Andernet-Posture/Andernet Posture/Views/MetricExplainerView.swift
@@ -35,7 +35,8 @@ extension MetricExplainer {
         ),
         "sva": MetricExplainer(
             metric: "Sagittal Vertical Axis (SVA)",
-            definition: "The horizontal distance between a vertical plumb line from C7 and the posterior superior corner of S1. Measures overall sagittal balance.",
+            definition: "The horizontal distance between a vertical plumb line from C7 and the "
+                + "posterior superior corner of S1. Measures overall sagittal balance.",
             normalRange: "< 5 cm",
             clinicalSignificance: "SVA greater than 5 cm indicates positive sagittal imbalance, which increases energy expenditure during standing and walking. Values >9.5 cm are associated with significant disability and pain.",
             icon: "arrow.up.and.down.text.horizontal",


### PR DESCRIPTION
## Summary
Fixed SwiftLint line-length violation in MetricExplainerView.swift.

## Changes
- Line 38: Split long definition string (164 chars → 2 lines of ~95 chars each)
- Used string concatenation to keep the code readable and semantic

## Evidence
Before:
```swift
definition: "The horizontal distance between a vertical plumb line from C7 and the posterior superior corner of S1. Measures overall sagittal balance.",
```

After:
```swift
definition: "The horizontal distance between a vertical plumb line from C7 and the "
            + "posterior superior corner of S1. Measures overall sagittal balance.",
```

Fixes and3rn3t/health#232