### PR TITLE
fix(deps): approve pnpm build scripts for native dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild
+  - msw
+  - sharp
+  - workerd
+
 allowBuilds:
   '@swc/core': true
   esbuild: true


### PR DESCRIPTION
Fixes #221

pnpm v10 introduced a security change requiring explicit opt-in for packages that run build scripts. This change adds `onlyBuiltDependencies` to `pnpm-workspace.yaml` to approve the following native dependencies:

- @swc/core
- esbuild  
- msw
- sharp
- workerd

This resolves the `ERR_PNPM_IGNORED_BUILDS` error in CI by explicitly approving these packages to run their build scripts during installation.