### PR TITLE
fix(e2e): wait for Suspense to resolve before asserting in chromium

### DIFF
--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -43,6 +43,15 @@ export class AppPage {
   async goto(): Promise<void> {
     await this.page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(this.mainContent.first()).toBeVisible();
+    // Wait for any Suspense boundary (lazy-loaded route components) to resolve.
+    // Chromium resolves domcontentloaded faster than other browsers, so without
+    // this guard, assertions run before React has rendered route content.
+    await this.page
+      .getByLabel('Loading content')
+      .waitFor({ state: 'hidden', timeout: 15_000 })
+      .catch(() => {
+        // No skeleton in DOM — content already loaded synchronously.
+      });
   }
 
   /**
@@ -64,6 +73,16 @@ export class AppPage {
     };
     await this.page.goto(pathByTab[tab], { waitUntil: 'domcontentloaded' });
     await expect(this.mainContent).toBeVisible();
+    // Wait for Suspense boundaries to resolve — each route lazy-loads its
+    // component, showing <DashboardSkeleton aria-label="Loading content"> until
+    // the chunk arrives. Chromium fires domcontentloaded before React renders,
+    // so without this wait the assertions run against an empty shell.
+    await this.page
+      .getByLabel('Loading content')
+      .waitFor({ state: 'hidden', timeout: 15_000 })
+      .catch(() => {
+        // No skeleton present — content loaded synchronously or was cached.
+      });
   }
 
   /**

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -7,6 +7,8 @@ test.describe('Visual Regression', () => {
   test('home page snapshot', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
+    // Wait for Suspense / lazy-loaded content to render before snapshotting
+    await page.getByLabel('Loading content').waitFor({ state: 'hidden', timeout: 15_000 }).catch(() => {});
 
     // Wait for animations/transitions to settle
     await page.waitForTimeout(500);
@@ -21,6 +23,7 @@ test.describe('Visual Regression', () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
+    await page.getByLabel('Loading content').waitFor({ state: 'hidden', timeout: 15_000 }).catch(() => {});
     await page.waitForTimeout(500);
 
     await expect(page).toHaveScreenshot('home-mobile.png', {
@@ -34,6 +37,7 @@ test.describe('Visual Regression', () => {
     await page.emulateMedia({ colorScheme: 'dark' });
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
+    await page.getByLabel('Loading content').waitFor({ state: 'hidden', timeout: 15_000 }).catch(() => {});
     await page.waitForTimeout(500);
 
     await expect(page).toHaveScreenshot('home-dark.png', {


### PR DESCRIPTION
## What Problem This Solves

All 30 functional chromium E2E tests were failing while Firefox and WebKit passed. Every route uses **double lazy loading**: TanStack Router's `autoCodeSplitting` lazy-loads the route module, then each route file wraps its component in `React.lazy()` + `Suspense`. Chromium resolves `domcontentloaded` faster than other browsers, so `navigateTo()` and `goto()` were returning before React had a chance to render route content — the assertions ran against an empty shell.

## Why This Change Was Made

The `DashboardSkeleton` (the Suspense fallback) has `aria-label="Loading content"`. Added a `.waitFor({ state: 'hidden' })` call after each navigation that blocks until the skeleton disappears, meaning lazy chunks have loaded and React has rendered the actual page content.

The same wait was added to the visual regression spec for stable rendering before taking snapshots.

## User Impact

Fixes the 30 chromium-specific functional E2E failures across fall-risk, gait-analysis, lidar-posture, settings, and navigation tests. Visual regression snapshot dimension mismatch is a pre-existing issue that requires a separate snapshot regeneration pass.

## Evidence

- Root cause: `waitUntil: 'domcontentloaded'` in `navigateTo()` resolves before `React.lazy()` chunk fetch completes
- Fix: `page.getByLabel('Loading content').waitFor({ state: 'hidden', timeout: 15_000 })`
- Only 2 files changed: `e2e/pages/app.page.ts` and `e2e/visual-regression.spec.ts`

Fixes and3rn3t/health#189