### PR TITLE
fix(e2e): two-step Suspense skeleton wait to eliminate race condition

### DIFF
--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -46,12 +46,16 @@ export class AppPage {
     // Wait for any Suspense boundary (lazy-loaded route components) to resolve.
     // Chromium resolves domcontentloaded faster than other browsers, so without
     // this guard, assertions run before React has rendered route content.
-    await this.page
-      .getByLabel('Loading content')
-      .waitFor({ state: 'hidden', timeout: 15_000 })
-      .catch(() => {
-        // No skeleton in DOM — content already loaded synchronously.
-      });
+    // Two-step: first wait for skeleton to appear (it may be too brief to catch
+    // with hidden-only wait), then wait for it to disappear.
+    const skeleton = this.page.getByLabel('Loading content');
+    const appeared = await skeleton
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (appeared) {
+      await skeleton.waitFor({ state: 'hidden', timeout: 15_000 });
+    }
   }
 
   /**
@@ -77,12 +81,17 @@ export class AppPage {
     // component, showing <DashboardSkeleton aria-label="Loading content"> until
     // the chunk arrives. Chromium fires domcontentloaded before React renders,
     // so without this wait the assertions run against an empty shell.
-    await this.page
-      .getByLabel('Loading content')
-      .waitFor({ state: 'hidden', timeout: 15_000 })
-      .catch(() => {
-        // No skeleton present — content loaded synchronously or was cached.
-      });
+    // Two-step: first wait for skeleton to appear (short timeout handles the
+    // case where content loads so fast the skeleton is never rendered), then
+    // wait for skeleton to disappear.
+    const skeleton = this.page.getByLabel('Loading content');
+    const appeared = await skeleton
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (appeared) {
+      await skeleton.waitFor({ state: 'hidden', timeout: 15_000 });
+    }
   }
 
   /**


### PR DESCRIPTION
## What Problem This Solves
`goto()` and `navigateTo()` use `waitFor({ state: 'hidden' })` on the Suspense skeleton, but this resolves immediately if the skeleton is not yet in the DOM — which happens when React hasn't started rendering the Suspense fallback yet. The result is that assertions run before lazy-loaded route content has rendered, causing fall-risk E2E tests to fail intermittently (especially in chromium and mobile-chrome).

## Why This Change Was Made
Switch to a two-step wait: try `state: 'visible'` with a 2 s timeout first. If the skeleton actually appeared, wait for `state: 'hidden'`. If the skeleton never shows (content loaded synchronously or was cached), skip the hidden wait. This eliminates the race condition while keeping fast paths fast.

## User Impact
Fixes the nightly E2E regression (health#250) and unblocks the fall-risk test suite across all browser projects.

Fixes #250